### PR TITLE
feat(userprog): Implement read system call

### DIFF
--- a/src/userprog/userutil.c
+++ b/src/userprog/userutil.c
@@ -39,3 +39,15 @@ bool copy_string_from_user(const char *src, char *dst, size_t max_len)
 	dst[max_len - 1] = '\0';
 	return true;
 }
+
+bool put_user_byte(uint8_t *udst, uint8_t byte)
+{
+	if (!is_user_vaddr(udst)) {
+		return false;
+	}
+	int error_code;
+	asm("movl $1f, %0; movb %b2, %1; 1:"
+	    : "=&a"(error_code), "=m"(*udst)
+	    : "q"(byte));
+	return error_code != -1;
+}

--- a/src/userprog/userutil.h
+++ b/src/userprog/userutil.h
@@ -13,6 +13,7 @@
 /* User memory access functions */
 int get_user_byte(const uint8_t *uaddr);
 int get_user_int(const uint8_t *uaddr);
+bool put_user_byte(uint8_t *udst, uint8_t byte);
 bool copy_string_from_user(const char *src, char *dst, size_t max_len);
 
 #endif /* userprog/userutil.h */


### PR DESCRIPTION
Add read syscall implementation with safe user memory access:
- Implement handle_read() for reading from STDIN
- Add put_user_byte() with page fault protection for safe writes to user memory
- Add SYS_READ case to syscall handler
- Fix include path for devices/input.h

The implementation validates user pointers and handles page faults to prevent kernel crashes from invalid user memory access.